### PR TITLE
tilføjet libnode-dev til dependencies

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -20,7 +20,8 @@ jobs:
             libx11-dev pandoc \
             libcurl4-openssl-dev \
             libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev \
-            libfontconfig1-dev libfribidi-dev libharfbuzz-dev
+            libfontconfig1-dev libfribidi-dev libharfbuzz-dev \
+            libnode-dev
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Pludselig fejlede tinytex installationen.
Githubs copilot foreslår at libnode-dev tilføjes render.yaml